### PR TITLE
feat: improve error message formatting

### DIFF
--- a/src/Analyzers/PluginReferenceNullableAnalyzer.cs
+++ b/src/Analyzers/PluginReferenceNullableAnalyzer.cs
@@ -1,0 +1,115 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RustAnalyzer.Utils;
+
+namespace RustAnalyzer.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class PluginReferenceNullableAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "RA0040";
+        private const string Category = "Usage";
+
+        private static readonly LocalizableString Title =
+            "Plugin reference field should be nullable";
+
+        private static readonly string NoteTemplate =
+            "field '{0}' of type '{1}' should be declared as nullable";
+
+        private static readonly string HelpTemplate =
+            "change the type to '{2}' to indicate that the plugin may not be available at runtime";
+
+        private static readonly string ExampleTemplate = "private readonly {2} {0};";
+
+        private static readonly LocalizableString Description =
+            "Fields marked with [PluginReference] attribute should be declared as nullable types to indicate that they may not be available at runtime.";
+
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            "{0}", // Placeholder for dynamic description
+            Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: Description,
+            helpLinkUri: "https://github.com/legov/rust-analyzer/blob/main/docs/RA0040.md"
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(AnalyzeField, SyntaxKind.FieldDeclaration);
+        }
+
+        private void AnalyzeField(SyntaxNodeAnalysisContext context)
+        {
+            var fieldDeclaration = (FieldDeclarationSyntax)context.Node;
+
+            // Проверяем наличие атрибута [PluginReference]
+            if (!HasPluginReferenceAttribute(fieldDeclaration))
+                return;
+
+            // Проверяем каждую переменную в объявлении поля
+            foreach (var variable in fieldDeclaration.Declaration.Variables)
+            {
+                // Получаем тип поля
+                var typeInfo = context.SemanticModel.GetTypeInfo(fieldDeclaration.Declaration.Type);
+                var fieldType = typeInfo.Type;
+                if (fieldType == null)
+                    continue;
+
+                // Проверяем, является ли тип nullable
+                bool isNullable =
+                    fieldDeclaration.Declaration.Type is NullableTypeSyntax
+                    || (fieldType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T);
+
+                if (!isNullable)
+                {
+                    var location = variable.GetLocation();
+                    var sourceText = location.SourceTree?.GetText();
+                    if (sourceText == null)
+                        continue;
+
+                    var parameters = new[]
+                    {
+                        variable.Identifier.Text, // {0} - имя поля
+                        fieldType.ToDisplayString(), // {1} - текущий тип
+                        fieldType.ToDisplayString() + "?", // {2} - правильный тип (с ?)
+                    };
+
+                    var formatInfo = new RustDiagnosticFormatter.DiagnosticFormatInfo
+                    {
+                        ErrorCode = DiagnosticId,
+                        ErrorTitle = "field with [PluginReference] attribute must be nullable",
+                        Location = location,
+                        SourceText = sourceText,
+                        MessageParameters = parameters,
+                        Note = NoteTemplate,
+                        Help = HelpTemplate,
+                        Example = ExampleTemplate,
+                    };
+
+                    var dynamicDescription = RustDiagnosticFormatter.FormatDiagnostic(formatInfo);
+                    var diagnostic = Diagnostic.Create(Rule, location, dynamicDescription);
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+        private bool HasPluginReferenceAttribute(FieldDeclarationSyntax fieldDeclaration)
+        {
+            return fieldDeclaration
+                .AttributeLists.SelectMany(al => al.Attributes)
+                .Any(attr => attr.Name.ToString() == "PluginReference");
+        }
+    }
+}

--- a/src/AnalyzersFix/PluginReferenceNullableAnalyzer.CodeFix.cs
+++ b/src/AnalyzersFix/PluginReferenceNullableAnalyzer.CodeFix.cs
@@ -1,0 +1,82 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using RustAnalyzer.Analyzers;
+
+namespace RustAnalyzer.AnalyzersFix
+{
+    [
+        ExportCodeFixProvider(
+            LanguageNames.CSharp,
+            Name = nameof(PluginReferenceNullableCodeFixProvider)
+        ),
+        Shared
+    ]
+    public class PluginReferenceNullableCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(PluginReferenceNullableAnalyzer.DiagnosticId);
+
+        public sealed override FixAllProvider GetFixAllProvider() =>
+            WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context
+                .Document.GetSyntaxRootAsync(context.CancellationToken)
+                .ConfigureAwait(false);
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            // Находим объявление поля, которое нужно исправить
+            var fieldDeclaration = root.FindToken(diagnosticSpan.Start)
+                .Parent.AncestorsAndSelf()
+                .OfType<FieldDeclarationSyntax>()
+                .First();
+
+            // Регистрируем CodeFix
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Make field nullable",
+                    createChangedDocument: c =>
+                        MakeFieldNullableAsync(context.Document, fieldDeclaration, c),
+                    equivalenceKey: nameof(PluginReferenceNullableCodeFixProvider)
+                ),
+                diagnostic
+            );
+        }
+
+        private async Task<Document> MakeFieldNullableAsync(
+            Document document,
+            FieldDeclarationSyntax fieldDecl,
+            CancellationToken cancellationToken
+        )
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var originalType = fieldDecl.Declaration.Type;
+
+            // Создаем новый тип с суффиксом ?
+            var newType = SyntaxFactory
+                .NullableType(originalType)
+                .WithLeadingTrivia(originalType.GetLeadingTrivia())
+                .WithTrailingTrivia(originalType.GetTrailingTrivia());
+
+            // Создаем новое объявление поля с nullable типом
+            var newFieldDecl = fieldDecl.WithDeclaration(fieldDecl.Declaration.WithType(newType));
+
+            // Заменяем старое объявление на новое
+            var newRoot = root.ReplaceNode(fieldDecl, newFieldDecl);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/src/Utils/RustDiagnosticFormatter.cs
+++ b/src/Utils/RustDiagnosticFormatter.cs
@@ -1,0 +1,100 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace RustAnalyzer.Utils
+{
+    public class RustDiagnosticFormatter
+    {
+        public class DiagnosticFormatInfo
+        {
+            public string ErrorCode { get; set; }
+            public string ErrorTitle { get; set; }
+            public Location Location { get; set; }
+            public SourceText SourceText { get; set; }
+            public string[] MessageParameters { get; set; }
+            public string Note { get; set; }
+            public string Help { get; set; }
+            public string Example { get; set; }
+        }
+
+        public static string FormatDiagnostic(DiagnosticFormatInfo info)
+        {
+            var lineSpan = info.Location.GetLineSpan();
+            var startLinePosition = lineSpan.StartLinePosition;
+
+            var lineText = info.SourceText.Lines[startLinePosition.Line].ToString();
+            lineText = TextAlignmentUtils.ExpandTabs(lineText, 4);
+
+            int charColumn = startLinePosition.Character;
+            string pointerLine = TextAlignmentUtils.CreatePointerLine(
+                lineText,
+                charColumn,
+                info.Location.SourceSpan.Length,
+                4
+            );
+
+            var fileName = System.IO.Path.GetFileName(
+                info.Location.SourceTree?.FilePath ?? string.Empty
+            );
+
+            var messageBuilder = new System.Text.StringBuilder();
+
+            // Заголовок ошибки
+            messageBuilder.AppendFormat("error[{0}]: {1}\n", info.ErrorCode, info.ErrorTitle);
+
+            // Информация о расположении
+            messageBuilder.AppendFormat(
+                "  --> {0}:{1}:{2}\n",
+                fileName,
+                startLinePosition.Line + 1,
+                charColumn + 1
+            );
+
+            // Показ кода с указателем на ошибку
+            messageBuilder.AppendLine("   |");
+            messageBuilder.AppendFormat("{0,4} | {1}\n", startLinePosition.Line + 1, lineText);
+            messageBuilder.AppendFormat("   | {0}\n", pointerLine);
+            messageBuilder.AppendLine("   |");
+
+            // Дополнительная информация
+            if (!string.IsNullOrEmpty(info.Note))
+            {
+                var formattedNote = FormatMessageWithParameters(info.Note, info.MessageParameters);
+                messageBuilder.AppendFormat("   = note: {0}\n", formattedNote);
+            }
+
+            if (!string.IsNullOrEmpty(info.Help))
+            {
+                var formattedHelp = FormatMessageWithParameters(info.Help, info.MessageParameters);
+                messageBuilder.AppendFormat("   = help: {0}\n", formattedHelp);
+            }
+
+            if (!string.IsNullOrEmpty(info.Example))
+            {
+                var formattedExample = FormatMessageWithParameters(
+                    info.Example,
+                    info.MessageParameters
+                );
+                messageBuilder.AppendLine("   = example:");
+                messageBuilder.AppendFormat("           {0}", formattedExample);
+            }
+
+            return messageBuilder.ToString();
+        }
+
+        private static string FormatMessageWithParameters(string message, string[] parameters)
+        {
+            if (parameters == null || parameters.Length == 0)
+                return message;
+
+            try
+            {
+                return string.Format(message, parameters);
+            }
+            catch (System.FormatException)
+            {
+                return message;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add RustDiagnosticFormatter utility class for consistent Rust-style error messages

- Update PluginReferenceNullableAnalyzer to use the new formatter

- Update MemberNotFoundAnalyzer to use the new formatter

- Add support for customizable note, help, and example sections in error messages

This change improves error message readability and maintainability by:

1. Centralizing error formatting logic

2. Making error messages more consistent across analyzers

3. Following Rust's error message style

4. Making it easier to modify error message format in one place

#35 